### PR TITLE
Allow the Java API to return null when a directive is not present

### DIFF
--- a/flexiconf-core/src/main/scala/se/blea/flexiconf/DefaultConfig.scala
+++ b/flexiconf-core/src/main/scala/se/blea/flexiconf/DefaultConfig.scala
@@ -36,6 +36,6 @@ private[flexiconf] case class DefaultConfig(private val config: ConfigNode) exte
   }
 
   override def contains(name: String) = {
-    directive(name).name != "unknown"
+    directives.exists(_.name == name)
   }
 }

--- a/flexiconf-core/src/main/scala/se/blea/flexiconf/DefaultDirective.scala
+++ b/flexiconf-core/src/main/scala/se/blea/flexiconf/DefaultDirective.scala
@@ -66,7 +66,7 @@ private[flexiconf] case class DefaultDirective(private val node: ConfigNode) ext
   override def args: List[Argument] = node.arguments
 
   override def contains(name: String) = {
-    directive(name).name != "unknown"
+    directives.exists(_.name == name)
   }
 
   override def directive(name: String): Directive = {

--- a/flexiconf-java-api/src/main/scala/se/blea/flexiconf/javaapi/Config.scala
+++ b/flexiconf-java-api/src/main/scala/se/blea/flexiconf/javaapi/Config.scala
@@ -8,8 +8,8 @@ class Config(private val _config: se.blea.flexiconf.Config) {
   def getDirectives: java.util.List[Directive] = _config.directives.map(new Directive(_))
 
 
-  def hasDirective(name: String): java.lang.Boolean = _config.directives.exists(_.name == name)
-  
+  def contains(name: String): java.lang.Boolean = _config.contains(name)
+
   @annotation.varargs
   def getDirectives(names: String*): java.util.List[Directive] = _config.directives
     .filter( d => names.contains(d.name) )

--- a/flexiconf-java-api/src/main/scala/se/blea/flexiconf/javaapi/Config.scala
+++ b/flexiconf-java-api/src/main/scala/se/blea/flexiconf/javaapi/Config.scala
@@ -7,15 +7,15 @@ import scala.collection.JavaConversions._
 class Config(private val _config: se.blea.flexiconf.Config) {
   def getDirectives: java.util.List[Directive] = _config.directives.map(new Directive(_))
 
+
+  def hasDirective(name: String): java.lang.Boolean = _config.directives.exists(_.name == name)
+  
   @annotation.varargs
   def getDirectives(names: String*): java.util.List[Directive] = _config.directives
     .filter( d => names.contains(d.name) )
     .map(new Directive(_))
 
-  def getDirective(name: String): Directive = _config.directives
-    .find(_.name == name)
-    .map(new Directive(_))
-    .orNull
+  def getDirective(name: String): Directive = new Directive(_config.directive(name))
 
   def getWarnings: java.util.List[String] = _config.warnings
 

--- a/flexiconf-java-api/src/main/scala/se/blea/flexiconf/javaapi/Directive.scala
+++ b/flexiconf-java-api/src/main/scala/se/blea/flexiconf/javaapi/Directive.scala
@@ -11,7 +11,7 @@ class Directive(private val _directive: se.blea.flexiconf.Directive) {
 
   def getDirectives: java.util.List[Directive] = _directive.directives.map(new Directive(_))
 
-  def hasDirective(name: String): java.lang.Boolean = _directive.directives.exists(_.name == name)
+  def contains(name: String): java.lang.Boolean = _directive.contains(name)
 
   @annotation.varargs
   def getDirectives(names: String*): java.util.List[Directive] = _directive.directives(names:_*).map(new Directive(_))

--- a/flexiconf-java-api/src/main/scala/se/blea/flexiconf/javaapi/Directive.scala
+++ b/flexiconf-java-api/src/main/scala/se/blea/flexiconf/javaapi/Directive.scala
@@ -11,6 +11,8 @@ class Directive(private val _directive: se.blea.flexiconf.Directive) {
 
   def getDirectives: java.util.List[Directive] = _directive.directives.map(new Directive(_))
 
+  def hasDirective(name: String): java.lang.Boolean = _directive.directives.exists(_.name == name)
+
   @annotation.varargs
   def getDirectives(names: String*): java.util.List[Directive] = _directive.directives(names:_*).map(new Directive(_))
 
@@ -20,6 +22,8 @@ class Directive(private val _directive: se.blea.flexiconf.Directive) {
   private def longArg(name: String): Option[Long] = _directive.argValue(name).longValue
   private def doubleArg(name: String): Option[Double] = _directive.argValue(name).doubleValue
   private def stringArg(name: String): Option[String] = _directive.argValue(name).stringValue
+
+  def hasArg(name: String): java.lang.Boolean = _directive.args.exists(_.name == name)
 
   def getBoolArg(name: String): java.lang.Boolean = boolArg(name).get
   def getBoolArg(name: String, default: java.lang.Boolean): java.lang.Boolean = boolArg(name).getOrElse[Boolean](default)

--- a/flexiconf-java-api/src/test/scala/se/blea/flexiconf/javaapi/ConfigSpec.scala
+++ b/flexiconf-java-api/src/test/scala/se/blea/flexiconf/javaapi/ConfigSpec.scala
@@ -21,11 +21,11 @@ class ConfigSpec extends FlatSpec with Matchers {
   behavior of "hasDirective"
 
   it should "return true for existing directives" in {
-    config.hasDirective("foo") shouldBe true
+    config.contains("foo") shouldBe true
   }
 
   it should "return false for directives that don't exist" in {
-    config.hasDirective("qux") shouldBe false
+    config.contains("qux") shouldBe false
   }
 
   behavior of "getDirectives"

--- a/flexiconf-java-api/src/test/scala/se/blea/flexiconf/javaapi/ConfigSpec.scala
+++ b/flexiconf-java-api/src/test/scala/se/blea/flexiconf/javaapi/ConfigSpec.scala
@@ -18,6 +18,15 @@ class ConfigSpec extends FlatSpec with Matchers {
 
   val config = new Config(new flexiconf.DefaultConfig(rootNode))
 
+  behavior of "hasDirective"
+
+  it should "return true for existing directives" in {
+    config.hasDirective("foo") shouldBe true
+  }
+
+  it should "return false for directives that don't exist" in {
+    config.hasDirective("qux") shouldBe false
+  }
 
   behavior of "getDirectives"
 
@@ -47,7 +56,10 @@ class ConfigSpec extends FlatSpec with Matchers {
     config.getDirective("foo").getName shouldEqual "foo"
   }
 
-  it should "return null if the directive doesn't exist" in {
-    config.getDirective("qux") shouldBe null
+  it should "throw IllegalStateException if the directive doesn't exist" in {
+    intercept[IllegalStateException] {
+      config.getDirective("qux")
+    }
   }
+
 }

--- a/flexiconf-java-api/src/test/scala/se/blea/flexiconf/javaapi/DirectiveSpec.scala
+++ b/flexiconf-java-api/src/test/scala/se/blea/flexiconf/javaapi/DirectiveSpec.scala
@@ -60,11 +60,11 @@ class DirectiveSpec extends FlatSpec with Matchers {
   behavior of "hasDirective"
 
   it should "return true for existing directives" in {
-    directive.hasDirective("foo") shouldBe true
+    directive.contains("foo") shouldBe true
   }
 
   it should "return false for directives that don't exist" in {
-    directive.hasDirective("qux") shouldBe false
+    directive.contains("qux") shouldBe false
   }
 
   behavior of "getDirectives"

--- a/flexiconf-java-api/src/test/scala/se/blea/flexiconf/javaapi/DirectiveSpec.scala
+++ b/flexiconf-java-api/src/test/scala/se/blea/flexiconf/javaapi/DirectiveSpec.scala
@@ -57,6 +57,15 @@ class DirectiveSpec extends FlatSpec with Matchers {
     directive.getArgs.get(5).getName shouldEqual "duration"
   }
 
+  behavior of "hasDirective"
+
+  it should "return true for existing directives" in {
+    directive.hasDirective("foo") shouldBe true
+  }
+
+  it should "return false for directives that don't exist" in {
+    directive.hasDirective("qux") shouldBe false
+  }
 
   behavior of "getDirectives"
 
@@ -92,6 +101,15 @@ class DirectiveSpec extends FlatSpec with Matchers {
     }
   }
 
+  behavior of "hasArg"
+
+  it should "return true for existing arguments" in {
+    directive.hasArg("boolean") shouldBe true
+  }
+
+  it should "return false for arguments that don't exist" in {
+    directive.hasArg("non-existent") shouldBe false
+  }
 
   behavior of "argument getters"
 
@@ -117,5 +135,11 @@ class DirectiveSpec extends FlatSpec with Matchers {
 
   it should "return duration argument values" in {
     directive.getDurationArg("duration") shouldEqual 900000
+  }
+
+  it should "throw an exception if the argument doesn't exist" in {
+    intercept[IllegalStateException] {
+      directive.getStringArg("non-existent")
+    }
   }
 }


### PR DESCRIPTION
Using the Java API to get an optional directive by name showed that there was no way to tell that the Directive was a NullValue. This would result in an exception being thrown when accessing it. I've added back the Option check for this part of the API.