### PR TITLE
Java API null handling improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Flexible configuration for JVM projects.
 
 **API**
 - Scala API
-- Java-friendly API
+- Java API
 
 **CLI tooling**
 - Config/schema inspection and debugging

--- a/flexiconf-core/src/main/scala/se/blea/flexiconf/DefaultConfig.scala
+++ b/flexiconf-core/src/main/scala/se/blea/flexiconf/DefaultConfig.scala
@@ -35,7 +35,6 @@ private[flexiconf] case class DefaultConfig(private val config: ConfigNode) exte
     }
   }
 
-  override def contains(name: String) = {
-    directives.exists(_.name == name)
-  }
+  override def contains(name: String) = directives.exists(_.name == name)
+  override def allows(name: String) = allowedDirectives.contains(name)
 }

--- a/flexiconf-core/src/main/scala/se/blea/flexiconf/DefaultDirective.scala
+++ b/flexiconf-core/src/main/scala/se/blea/flexiconf/DefaultDirective.scala
@@ -65,9 +65,11 @@ private[flexiconf] case class DefaultDirective(private val node: ConfigNode) ext
 
   override def args: List[Argument] = node.arguments
 
-  override def contains(name: String) = {
-    directives.exists(_.name == name)
-  }
+  override def contains(name: String) = directives.exists(_.name == name)
+  override def containsArg(name: String) = args.exists(_.name == name)
+
+  override def allows(name: String) = allowedDirectives.contains(name)
+  override def allowsArg(name: String) = allowedArguments.contains(name)
 
   override def directive(name: String): Directive = {
     if (allowedDirectives.contains(name)) {

--- a/flexiconf-core/src/main/scala/se/blea/flexiconf/Directive.scala
+++ b/flexiconf-core/src/main/scala/se/blea/flexiconf/Directive.scala
@@ -16,6 +16,10 @@ trait Directive extends TraversableConfig {
   def or(other: ArgumentValue): ArgumentValue = apply | other
   def |(other: ArgumentValue) = or(other)
 
+  /** Returns whether an argument is allowed and contained for this directive **/
+  def allowsArg(name: String): Boolean
+  def containsArg(name: String): Boolean
+
   /** Find an argument by name **/
   def argValue(name: String): ArgumentValue
 

--- a/flexiconf-core/src/main/scala/se/blea/flexiconf/TraversableConfig.scala
+++ b/flexiconf-core/src/main/scala/se/blea/flexiconf/TraversableConfig.scala
@@ -27,9 +27,13 @@ trait TraversableConfig {
   def directive(names: (String, String, String, String, String, String)): (Directive, Directive, Directive, Directive, Directive, Directive) =
     (directive(names._1), directive(names._2), directive(names._3), directive(names._4), directive(names._5), directive(names._6))
 
-  /** Returns whether or not this directive exists within this context **/
+  /** Returns whether or not the named directive exists within this context **/
   def contains(name: String) : Boolean
   def ?(name: String)  = contains(name)
+
+  /** Returns whether or not the named directive is allowed within this context **/
+  def allows(name: String): Boolean
+  def ??(name: String): Boolean = allows(name)
 
   /** Operators for alternative traversal of configuration **/
   def \(name: String) = directive(name)

--- a/flexiconf-java-api/src/main/scala/se/blea/flexiconf/javaapi/Directive.scala
+++ b/flexiconf-java-api/src/main/scala/se/blea/flexiconf/javaapi/Directive.scala
@@ -23,23 +23,23 @@ class Directive(private val _directive: se.blea.flexiconf.Directive) {
   private def doubleArg(name: String): Option[Double] = _directive.argValue(name).doubleValue
   private def stringArg(name: String): Option[String] = _directive.argValue(name).stringValue
 
-  def hasArg(name: String): java.lang.Boolean = _directive.args.exists(_.name == name)
+  def hasArg(name: String): java.lang.Boolean = _directive.allowsArg(name)
 
-  def getBoolArg(name: String): java.lang.Boolean = boolArg(name).get
+  def getBoolArg(name: String): java.lang.Boolean = boolArg(name).getOrElse[Boolean](false)
   def getBoolArg(name: String, default: java.lang.Boolean): java.lang.Boolean = boolArg(name).getOrElse[Boolean](default)
 
-  def getPercentageArg(name: String): java.lang.Double = doubleArg(name).get
+  def getPercentageArg(name: String): java.lang.Double = doubleArg(name).getOrElse[Double](0.0)
   def getPercentageArg(name: String, default: java.lang.Double): java.lang.Double = doubleArg(name).getOrElse[Double](default)
 
-  def getDecimalArg(name: String): java.lang.Double = doubleArg(name).get
+  def getDecimalArg(name: String): java.lang.Double = doubleArg(name).getOrElse[Double](0.0)
   def getDecimalArg(name: String, default: java.lang.Double): java.lang.Double = doubleArg(name).getOrElse[Double](default)
 
-  def getStringArg(name: String): java.lang.String = stringArg(name).get
+  def getStringArg(name: String): java.lang.String = stringArg(name).getOrElse[String]("")
   def getStringArg(name: String, default: java.lang.String): java.lang.String = stringArg(name).getOrElse[String](default)
 
-  def getIntArg(name: String): java.lang.Long = longArg(name).get
+  def getIntArg(name: String): java.lang.Long = longArg(name).getOrElse[Long](0l)
   def getIntArg(name: String, default: java.lang.Long): java.lang.Long = longArg(name).getOrElse[Long](default)
 
-  def getDurationArg(name: String): java.lang.Long = longArg(name).get
+  def getDurationArg(name: String): java.lang.Long = longArg(name).getOrElse[Long](0l)
   def getDurationArg(name: String, default: java.lang.Long): java.lang.Long = longArg(name).getOrElse[Long](default)
 }


### PR DESCRIPTION
These changes address the `java.util.NoSuchElementException` on `None.get` when accessing argument values through the Java API by returning zero values for arguments that cannot be cast to the requested type or have been retrieved from non-existent directives. This makes the Java API behave more similarly to the Scala API.

Additionally, I added methods for checking whether a directive or argument is allowed or exists. In the case of arguments, if an argument is allowed it will exist, but in the case of directives a directive may be allowed but not exist.