### PR TITLE
Bump antlr plugin to slim run-time dependency profile

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ resolvers ++= Seq(
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.7.0")
 
-addSbtPlugin("com.simplytyped" % "sbt-antlr4" % "0.7.4")
+addSbtPlugin("com.simplytyped" % "sbt-antlr4" % "0.7.7")
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.13.0")
 


### PR DESCRIPTION
This changes the dependency profile to look like:

```
[info] se.blea.flexiconf:flexiconf-core_2.11:0.1.1-SNAPSHOT [S]
[info]   +-commons-io:commons-io:2.4
[info]   +-org.antlr:antlr4-runtime:4.5.1
```

Instead of:

```
[info] se.blea.flexiconf:flexiconf-core_2.11:0.1.1-SNAPSHOT [S]
[info]   +-commons-io:commons-io:2.4
[info]   +-org.antlr:antlr4:4.5
[info]     +-org.antlr:ST4:4.0.8
[info]     | +-org.antlr:antlr-runtime:3.5.2
[info]     |
[info]     +-org.antlr:antlr-runtime:3.5.2
[info]     +-org.antlr:antlr4-runtime:4.5
[info]       +-org.abego.treelayout:org.abego.treelayout.core:1.0.1
```

This means that we can now include `flexiconf-core` in other projects that use assembly without the consumer having to add dependency exclusions or merge strategies for dealing with duplicate classes from the library's dependencies.